### PR TITLE
Add whitelist option for authorization header

### DIFF
--- a/lib/Chrome.js
+++ b/lib/Chrome.js
@@ -4,7 +4,7 @@ var PrefServ = require("./PrefServ"),
     Panel = require("./Panel"),
     Timer = require("./Timer"),
     ContextMenu = require("./ContextMenu"),
-    whiteListStateArray = new Array (4), //to store the state of the header whitelist options
+    whiteListStateArray = new Array (5), //to store the state of the header whitelist options
     panel = null, //Panel.getPanel() will not work at this point
     Observer =
 {
@@ -92,7 +92,7 @@ var PrefServ = require("./PrefServ"),
 				}
 				
                 // Don't send HTTP Authorization header
-                if(PrefServ.getter("extensions.agentSpoof.authorization") == true){
+                if(PrefServ.getter("extensions.agentSpoof.authorization") == true && whiteListStateArray[4] == false){
                     httpChannel.setRequestHeader("Authorization","",false);
                 }
 
@@ -203,6 +203,10 @@ function checkWhiteListConfig(index){
         //check if sending of the if-none-match header has been whitelisted to disallow it
         if(whiteListItem.options.indexOf("ifnonematch") > -1)
             whiteListStateArray[3] = true;
+
+        //check if sending of the if-none-match header has been whitelisted to disallow it
+        if(whiteListItem.options.indexOf("authorization") > -1)
+            whiteListStateArray[4] = true;
 
     }
 };


### PR DESCRIPTION
This commit adds an option to whitelist the authorization header for specific sites. I works the same as the other whitelist options for headers and the new code is more or less a clone of the lines for the "ifnonematch" header.

Merging this commit will fix the issues #92 and #141.