### PR TITLE
CSS and markup cleanup (mostly)

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -1,9 +1,21 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,details,figcaption,figure,footer,header,hgroup,main,menu,nav,section,summary{display:block}audio,canvas,progress,video{display:inline-block;vertical-align:baseline}audio:not([controls]){display:none;height:0}[hidden],template{display:none}a{background-color:transparent}a:active,a:hover{outline:0}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:bold}dfn{font-style:italic}h1{font-size:2em;margin:.67em 0}mark{background:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:1em 40px}hr{box-sizing:content-box;height:0}pre{overflow:auto}code,kbd,pre,samp{font-family:monospace,monospace;font-size:1em}button,input,optgroup,select,textarea{color:inherit;font:inherit;margin:0}button{overflow:visible}button,select{text-transform:none}button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}button[disabled],html input[disabled]{cursor:default}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}input{line-height:normal}input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}input[type="number"]::-webkit-inner-spin-button,input[type="number"]::-webkit-outer-spin-button{height:auto}input[type="search"]{-webkit-appearance:textfield;box-sizing:content-box}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}legend{border:0;padding:0}textarea{overflow:auto}optgroup{font-weight:bold}table{border-collapse:collapse;border-spacing:0}td,th{padding:0}
+
+
+/* global
+------------------------ */
+
+* {
+	-webkit-box-sizing: border-box;
+	   -moz-box-sizing: border-box;
+			box-sizing: border-box;
+}
 body {
 	background: #fff;
+	font-family: sans-serif;
+	font-size: 12.8px;
 	margin: 0;
-	font-size: .8em;
 }
-
 hr {
 	border: 0;
 	border-top: 1px solid #ccc;
@@ -11,59 +23,23 @@ hr {
 	height: 1px;
 	margin: 1.5em 0;
 }
-h2{
-	text-align: center;
+.hidden {
+	display:none;
 }
-
-input,
-label{
-	cursor:pointer;
-}
-
-#viaip,
-#xffip{
-	width:130px;
-}
-
-.iplabel{
-	display:inline-block;
-	width:50px;
-}
-#tabs li > span{
-	cursor: pointer;
-	display: inline-block;
-	padding: .5em;
-	text-align: center;
-	width: 23%;
-	height: 5%;
+#tabs,
+#top_profile_radios ul,
+#ualist ul {
 	list-style-type: none;
+	padding: 0;
+	margin: 0;
 }
 
-#tabs li:last-child > span {
-	width: 8%;
-	cursor: help;
+/* input */
+
+input:not([type="text"]),
+label {
+	cursor: pointer;
 }
-
-ul{ 
-	list-style-type:none;
-	padding:0px;
-	margin:0px;
-}		
-
-#top_profile_radios ul:first-child li {
-	display: inline-block;
-	width: 50%;
-}
-
-#top_profile_radios{
-	margin-bottom: 2px;
-}
-
-.innerlist{
-	padding:0;
-	display: none;
-}		
-
 input[type="radio"],
 input[type="checkbox"] {
 	display: inline-block;
@@ -76,136 +52,148 @@ input[type="radio"]:checked + label {
 	font-weight: bold;
 }
 input[type="radio"][id="default"]:checked + label {
-		color: #000;
+	color: #000;
+}
+.validInput {
+	border: solid 2px #cbe86b;
+	-moz-transition: .3s ease-in-out;
+}
+.invalidInput {
+	border: solid 2px #c02942;
+	-moz-transition: .3s ease-in-out;
 }
 
-.listitem_p,
-#wl_prof_expand,
-#wl_rules_expand {
-	background: #ccc;
+
+/* tabs
+------------------------ */
+
+#tabs li {
+	display: inline;
+}
+#tabs li span {
 	cursor: pointer;
-	margin-top: 2px;
-	margin-bottom: 0;
-	margin-right: 0;
-	margin-left: 0;
+	display: inline-block;
 	padding: .5em;
-	position: relative;
+	text-align: center;
+	width: 23%;
 }
-
-.listitem_p_spoof{
-	background: #219be2;
-	color: #fff;
-	cursor: pointer;
-	margin-top: 2px;
-	margin-bottom: 0;
-	margin-right: 0;
-	margin-left: 0;
-	padding: .5em;
-	position: relative;
+#tabs li:last-child span {
+	cursor: help;
+	width: 8%;
 }
-
-
-#tabs { 
-	list-style-type: none; 
-	padding: 0; 
-	margin: 0;
+#tabs li span:hover {
+	opacity: .6;
 }
-
-#tabs li { 
-	display: inline; 
-}
-
-#tabs li span.nonselected { 
-	padding: 0em; 
-	text-decoration: none; 
+#tabs li span.nonselected {
 	background: #000;
-	color:#fff;
-	margin: 0;
-	text-align: center;
+	color: #fff;
 }
-
-#tabs li span.selected { 
-	font-weight: bold; 
-	padding: 0em; 
+#tabs li span.selected {
 	background: #fff;
-	color:#000;
-	margin: 0;
-	text-align: center;
+	color: #000;
+	font-weight: bold;
 }
-
-.spoof #tabs li span.nonselected { 
+.spoof #tabs li span.nonselected {
 	background: #219be2;
 }
-
-.spoof #tabs li span.selected { 
+.spoof #tabs li span.selected {
 	color: #219be2;
 }
 
-#tabs li span:hover { 
-	opacity: 0.6;
+
+/* .tabContent
+------------------------ */
+
+.tabContent {
+	padding: 2em 1.5em;
 }
 
-.tabContent { 
-	padding: 0.5em; 
-	overflow:hidden;
-	background: #fff;
-	color:#000;
-	margin:none;
+/* profile tab */
+
+#top_profile_radios ul {
+	-moz-columns: 2;
+		 columns: 2;
+	margin-bottom: 1.5em;
+}
+#top_profile_radios ul li {
+	display: inline-block;
+	width: 100%;
+}
+#ualist {
+	margin-top: 1.5em;
+}
+.innerlist {
+	display: none;
+}
+.listitem_p,
+.listitem_p_spoof,
+#wl_prof_expand,
+#wl_rules_expand {
+	cursor: pointer;
+	margin: 1px 0 0 0;
+	padding: .5em;
+	position: relative;
+}
+.listitem_p,
+#wl_prof_expand,
+#wl_rules_expand {
+	background: rgba(0, 0, 0, 0.1);
+}
+.listitem_p_spoof {
+	background: #219be2;
+	color: #fff;
 }
 
-.validInput{
-	border: solid 2px #219be2;
-	-moz-transition: .3s ease-in-out;
+/* headers tab */
+
+.iplabel {
+	display: inline-block;
+	width: 25%;
 }
-
-.invalidInput{
-	border: solid 2px #000000;
-	-moz-transition: .3s ease-in-out;
+.iplabel + input {
+	display: inline-block;
+	width: 75%;
 }
-
-.profileLine{
-	clear:both;
+.profileLine {
+	clear: both;
 }
-
-
 .indicatorSpan,
 #wl_prof_title_span,
 #wl_rules_title_span,
 .excludecb,
-.excludeSpan{
-	float:right;
+.excludeSpan {
+	float: right;
 }
 
-.ddright{
-	clear:both;
-	overflow: hidden;
-}
+/* extras tab */
 
 .ddspan{
 	float:right;
 }
+.ddright {
+	clear: both;
+	overflow: hidden;
+}
 
-#site_whitelist{
-	resize:none;
+/* whitelist tab */
+
+#site_whitelist {
+	height: 60%;
+	margin-top: 1.5em;
+	resize: none;
+	width: 100%;
+}
+.wl_prof {
 	width:100%;
-	height:60%;
 }
 
-.wl_prof{
-	width:100%;
-}
+/* help tab */
 
-#whitelist_profile{
-	padding:5px;
-	overflow:hidden;
+h2 {
+	margin-top: 0;
 }
-
-.customlink{
-	text-decoration: underline;
+.customlink {
+	color:	blue;
 	cursor: pointer;
-	color:	#219be2;
-}
-
-.hidden{
-	display:none;
+	text-decoration: underline;
 }

--- a/data/html/options-panel.html
+++ b/data/html/options-panel.html
@@ -57,7 +57,6 @@
 									<option value="60" data-l10n-id="60_mins_id"></option>
 							</select>
 						</div>
-					<hr>
 
 						<div id ="ualist"></div>
 				</div>

--- a/data/html/options-panel.html
+++ b/data/html/options-panel.html
@@ -123,7 +123,7 @@
 
 							<!--	</span	data-l10n-id="screen_github_only_id" ></span> -->
 
-							<label for="screendd"  data-l10n-id="screen_spoofing_id" ></label>
+							<label for="screendd" data-l10n-id="screen_spoofing_id" ></label>
 
 								<span class="ddspan">
 										<select id="screendd" class="dd" data-prefname="extensions.agentSpoof.screenSize">
@@ -199,7 +199,7 @@
 						<input type="checkbox" id="webrtc" data-invertvalue="true" data-prefname="media.peerconnection.enabled"/>
 						<label for="webrtc" data-l10n-id="disable_webrtc_id" ></label><br>
 
-						<input type="checkbox" id="pdfjs"  data-invertvalue="false" data-prefname="pdfjs.disabled"/>
+						<input type="checkbox" id="pdfjs" data-invertvalue="false" data-prefname="pdfjs.disabled"/>
 						<label for="pdfjs" data-l10n-id="disable_pdfjs_id" ></label><br>
 
 						<input type="checkbox" id="search_suggest" data-invertvalue="true" data-prefname="browser.search.suggest.enabled"/>
@@ -232,13 +232,13 @@
 						<div align ="center"><b data-l10n-id="header_options_id"></b></div>
 
 						<input type="checkbox" id="auth" data-invertvalue="false" data-prefname="extensions.agentSpoof.authorization"/>
-						<label for="auth"  data-l10n-id="disable_auth_header_id"></label><br>
+						<label for="auth" data-l10n-id="disable_auth_header_id"></label><br>
 
 						<input type="checkbox" id="dnt" data-invertvalue="false" data-prefname="privacy.donottrackheader.enabled"/>
 						<label for="dnt" data-l10n-id="dnt_header_id" ></label><br>
 
 						<input type="checkbox" id="ifnone" data-invertvalue="false" data-prefname="extensions.agentSpoof.ifnone"/>
-						<label for="ifnone"  data-l10n-id="if_none_header_id"></label><br>
+						<label for="ifnone" data-l10n-id="if_none_header_id"></label><br>
 
 						<div class="ddright">
 								<input type="checkbox" id="xff" data-invertvalue="false" data-prefname="extensions.agentSpoof.xff"/>
@@ -261,7 +261,7 @@
 								<input type="checkbox" id="via" data-invertvalue="false" data-prefname="extensions.agentSpoof.via"/>
 								<label for="via" data-l10n-id="via_header_id"></label>
 								<span class="ddspan">
-							<select class="ipdropdown" id="viadd" data-prefname="extensions.agentSpoof.viadd"  data-uipref="customvia">
+							<select class="ipdropdown" id="viadd" data-prefname="extensions.agentSpoof.viadd" data-uipref="customvia">
 												<option value="random"	data-l10n-id="random_ip_id" ></option>
 												<option value="custom"	data-l10n-id="custom_ip_id" ></option>
 							</select>

--- a/data/html/options-panel.html
+++ b/data/html/options-panel.html
@@ -58,7 +58,7 @@
 							</select>
 						</div>
 
-						<div id ="ualist"></div>
+						<div id="ualist"></div>
 				</div>
 
 				<div id="extras_tab_content" class="hidden">

--- a/data/html/options-panel.html
+++ b/data/html/options-panel.html
@@ -1,398 +1,445 @@
 <html>
-		<head>
-				<meta charset="utf-8">
-				<link rel="stylesheet" type="text/css" media="all" href="../css/style.css"/>
-				<script src="optionspage.js" type="text/javascript"></script>
-		</head>
-
-		<body>
-
-				<div id="tabs_container">
-						<ul id="tabs">
-								<li><span id="ua_tab" class="selected" data-l10n-id="profile_tab_id"></span></li><!--
-						 --><li><span id="headers_tab" class="nonselected" data-l10n-id="headers_tab_id"></span></li><!--
-						 --><li><span id="extras_tab" class="nonselected" data-l10n-id="extras_tab_id"></span></li><!--
-						 --><li><span id="whitelist_tab" class="nonselected" data-l10n-id="whitelist_tab_id"></span></li><!--
-						 --><li><span id="help_tab" class="nonselected" data-l10n-id="help_tab_id"></span></li>
-						</ul>
-				</div>
-
-				<div id="ua_tab_content" class="tabContent">
-
-						<div id="top_profile_radios">
-								<ul>
-										<li>
-												<input type="radio" name="ua" id="default" value="default">
-											<label for="default" data-l10n-id="real_id"></label>
-										</li><!--
-								 --><li>
-												<input type="radio" name="ua" id="random_desktop" value="random_desktop">
-											<label for="random_desktop" data-l10n-id="random_desktop_id"></label>
-										</li><!--
-								 --><li>
-												<input type="radio" name="ua" id="random" value="random">
-												<label for="random" data-l10n-id="random_id"></label>
-										</li><!--
-								 --><li>
-												<input type="radio" name="ua" id="random_mobile" value="random_mobile">
-												<label for="random_mobile" data-l10n-id="random_mobile_id"></label>
-										</li>
-								</ul>
-						</div>
-
-						<div id="time_interval_display" class="hidden">
-							<span data-l10n-id="change_on_timer_id"></span>
-
-							<select id="timerdd">
-										<option value="none" data-l10n-id="no_timer_id"></option>
-										<option value="randomTime" data-l10n-id="random_id"></option>
-									<option value="request" data-l10n-id="per_request_id"></option>
-									<option value="1" data-l10n-id="1_min_id"></option>
-									<option value="5" data-l10n-id="5_mins_id"></option>
-									<option value="10" data-l10n-id="10_mins_id"></option>
-									<option value="20" data-l10n-id="20_mins_id"></option>
-									<option value="30" data-l10n-id="30_mins_id"></option>
-									<option value="40" data-l10n-id="40_mins_id"></option>
-									<option value="50" data-l10n-id="50_mins_id"></option>
-									<option value="60" data-l10n-id="60_mins_id"></option>
-							</select>
-						</div>
-
-						<div id="ualist"></div>
-				</div>
-
-				<div id="extras_tab_content" class="hidden">
-						<div align ="center"><b data-l10n-id="extra_privacy_options_id" ></b></div>
-
-						<div class="ddright">
-
-							 <!-- <span data-l10n-id="tz_github_only_id"></span>-->
-
-								<label for="tzdd" data-l10n-id="tz_spoofing_id"></label>
-
-								<span class="ddspan">
-										<select id="tzdd" class="dd" data-prefname="extensions.agentSpoof.tzOffset">
-												<option value="default" data-l10n-id="default_id" ></option>
-												<option value="random"	data-l10n-id="random_id" ></option>
-												<option value="12">-12:00</option>
-												<option value="11">-11:00</option>
-												<option value="10">-10:00</option>
-												<option value="9.5">-09:30</option>
-												<option value="9">-09:00</option>
-												<option value="8">-08:00</option>
-												<option value="7">-07:00</option>
-												<option value="6">-06:00</option>
-												<option value="5">-05:00</option>
-												<option value="4.5">-04:30</option>
-												<option value="4">-04:00</option>
-												<option value="3.5">-03:30</option>
-												<option value="3">-03:00</option>
-												<option value="2">-02:00</option>
-												<option value="1">-01:00</option>
-												<option value="0">00:00</option>
-												<option value="-1">+01:00</option>
-												<option value="-2">+02:00</option>
-												<option value="-3">+03:00</option>
-												<option value="-3.5">+03:30</option>
-												<option value="-4">+04:00</option>
-												<option value="-4.5">+04:30</option>
-												<option value="-5">+05:00</option>
-												<option value="-5.5">+05:30</option>
-												<option value="-5.75">+05:45</option>
-												<option value="-6">+06:00</option>
-												<option value="-6.5">+06:30</option>
-												<option value="-7">+07:00</option>
-												<option value="-8">+08:00</option>
-												<option value="-8.75">+08:45</option>
-												<option value="-9">+09:00</option>
-												<option value="-9.5">+09:30</option>
-												<option value="-10">+10:00</option>
-												<option value="-10.5">+10:30</option>
-												<option value="-11">+11:00</option>
-												<option value="-11.5">+11:30</option>
-												<option value="-12">+12:00</option>
-												<option value="-12.75">+12:45</option>
-												<option value="-13">+13:00</option>
-												<option value="-14">+14:00</option>
-										</select>
-								</span>
-								<br>
-						</div>
-
-						<div class="ddright">
-
-							<!--	</span	data-l10n-id="screen_github_only_id" ></span> -->
-
-							<label for="screendd" data-l10n-id="screen_spoofing_id" ></label>
-
-								<span class="ddspan">
-										<select id="screendd" class="dd" data-prefname="extensions.agentSpoof.screenSize">
-												<option value="default" data-l10n-id="default_id"></option>
-												<option value="random" data-l10n-id="random_id"></option>
-												<option value="profile" data-l10n-id="profile_id"></option>
-												<option value="800x600">800x600</option>
-												<option value="1024x600">1024x600</option>
-												<option value="1024x768">1024x768</option>
-												<option value="1152x864">1152x864</option>
-												<option value="1280x720">1280x720</option>
-												<option value="1280x768">1280x768</option>
-												<option value="1280x800">1280x800</option>
-												<option value="1280x960">1280x960</option>
-												<option value="1280x1024">1280x1024</option>
-												<option value="1360x768">1360x768</option>
-												<option value="1366x768">1366x768</option>
-												<option value="1440x900">1440x900</option>
-												<option value="1400x1050">1400x1050</option>
-												<option value="1600x900">1600x900</option>
-												<option value="1600x1200">1600x1200</option>
-												<option value="1680x1050">1680x1050</option>
-												<option value="1920x1080">1920x1080</option>
-												<option value="1920x1200">1920x1200</option>
-												<option value="2048x1152">2048x1152</option>
-												<option value="2560x1440">2560x1440</option>
-												<option value="2560x1600">2560x1600</option>
-										</select>
-								</span>
-								<br>
-						</div>
-
-
-						<input type="checkbox" id="winname"data-invertvalue="false" data-prefname="extensions.agentSpoof.windowName"/>
-						<label for="winname" data-l10n-id="protect_window_name_id" ></label><br>
-
-						<input type="checkbox" id="canvas" data-invertvalue="false" data-prefname="extensions.agentSpoof.canvas"/>
-						<label for="canvas" data-l10n-id="disable_canvas_support_id" ></label><br>
-
-						<input type="checkbox" id="fonts"/>
-						<label for="fonts" data-l10n-id="use_standard_font_id" ></label><br>
-
-						<input type="checkbox"id="dom" data-invertvalue="true" data-prefname="dom.storage.enabled"/>
-						<label for="dom" data-l10n-id="disable_local_dom_storage_id" ></label><br>
-
-						<input type="checkbox" id="tab_history" data-invertvalue="false" data-prefname="extensions.agentSpoof.limitTab"/>
-						<label for="tab_history" data-l10n-id="limit_tab_history_id" ></label><br>
-
-						<input type="checkbox" id="browsing_downloads" data-invertvalue="true" data-prefname="places.history.enabled"/>
-						<label for="browsing_downloads" data-l10n-id="disable_browsing_history_id" ></label><br>
-
-						<input type="checkbox" id="cache_memory" data-invertvalue="true" data-prefname="browser.cache.memory.enable"/>
-						<label for="cache_memory" data-l10n-id="disable_memory_cache_id" ></label><br>
-
-						<input type="checkbox" id="cache_disk" data-invertvalue="true" data-prefname="browser.cache.disk.enable"/>
-						<label for="cache_disk" data-l10n-id="disable_disk_cache_id" ></label><br>
-
-						<input type="checkbox" id="cache_network" data-invertvalue="true" data-prefname="network.http.use-cache"/>
-						<label for="cache_network" data-l10n-id="disable_network_cache_id" ></label><br>
-
-						<input type="checkbox" id="geo" data-invertvalue="true" data-prefname="geo.enabled"/>
-						<label for="geo" data-l10n-id="disable_geolocation_id" ></label><br>
-
-						<input type="checkbox" id="link" data-invertvalue="true" data-prefname="network.prefetch-next"/>
-						<label for="link" data-l10n-id="disable_link_prefetching_id" ></label><br>
-
-						<input type="checkbox" id="dns" data-invertvalue="false" data-prefname="network.dns.disablePrefetch"/>
-						<label for="dns" data-l10n-id="disable_dns_prefetching_id" ></label><br>
-
-						<input type="checkbox" id="webgl" data-invertvalue="false" data-prefname="webgl.disabled"/>
-						<label for="webgl" data-l10n-id="disable_webgl_id" ></label><br>
-
-						<input type="checkbox" id="webrtc" data-invertvalue="true" data-prefname="media.peerconnection.enabled"/>
-						<label for="webrtc" data-l10n-id="disable_webrtc_id" ></label><br>
-
-						<input type="checkbox" id="pdfjs" data-invertvalue="false" data-prefname="pdfjs.disabled"/>
-						<label for="pdfjs" data-l10n-id="disable_pdfjs_id" ></label><br>
-
-						<input type="checkbox" id="search_suggest" data-invertvalue="true" data-prefname="browser.search.suggest.enabled"/>
-						<label for="search_suggest" data-l10n-id="disable_search_suggestions_id" ></label><br>
-
-						<input type="checkbox" id="dom_performance" data-invertvalue="true" data-prefname="dom.enable_performance"/>
-						<label for="dom_performance" data-l10n-id="dom_performance_id" ></label><br>
-
-						<input type="checkbox" id="dom_battery" data-invertvalue="true" data-prefname="dom.battery.enabled"/>
-						<label for="dom_battery" data-l10n-id="dom_battery_id" ></label><br>
-
-						<input type="checkbox" id="dom_gamepad" data-invertvalue="true" data-prefname="dom.gamepad.enabled"/>
-						<label for="dom_gamepad" data-l10n-id="dom_gamepad_id" ></label><br>
-
-						<input type="checkbox" id="clicktoplay" data-invertvalue="false" data-prefname="plugins.click_to_play"/>
-						<label for="clicktoplay" data-l10n-id="click_to_play_id" ></label><br>
-
-						<input type="checkbox" id="mixed_content_active" data-invertvalue="false"
-						data-prefname="security.mixed_content.block_active_content"/>
-						<label for="mixd_content_active" data-l10n-id="mixed_content_active_id" ></label><br>
-
-						<input type="checkbox" id="mixed_content_display" data-invertvalue="false"
-						data-prefname="security.mixed_content.block_display_content"/>
-						<label for="mixed_content_display" data-l10n-id="mixed_content_display_id" ></label><br>
-
-
-				</div>
-
-				<div id="headers_tab_content" class="hidden">
-						<div align ="center"><b data-l10n-id="header_options_id"></b></div>
-
-						<input type="checkbox" id="auth" data-invertvalue="false" data-prefname="extensions.agentSpoof.authorization"/>
-						<label for="auth" data-l10n-id="disable_auth_header_id"></label><br>
-
-						<input type="checkbox" id="dnt" data-invertvalue="false" data-prefname="privacy.donottrackheader.enabled"/>
-						<label for="dnt" data-l10n-id="dnt_header_id" ></label><br>
-
-						<input type="checkbox" id="ifnone" data-invertvalue="false" data-prefname="extensions.agentSpoof.ifnone"/>
-						<label for="ifnone" data-l10n-id="if_none_header_id"></label><br>
-
-						<div class="ddright">
-								<input type="checkbox" id="xff" data-invertvalue="false" data-prefname="extensions.agentSpoof.xff"/>
-								<label for="xff"	data-l10n-id="xff_header_id"></label>
-								<span class="ddspan">
-							<select class="ipdropdown" id="xffdd" data-prefname="extensions.agentSpoof.xffdd" data-uipref="customxff">
-								<option value="random"	data-l10n-id="random_ip_id" ></option>
-								<option value="custom"	data-l10n-id="custom_ip_id" ></option>
-							</select>
-								</span>
-								<br>
-						</div>
-
-			<div id="customxff" class="hidden">
-				<label for="xffip" class="iplabel" data-l10n-id="xff_ip_id"></label><input type="text" id="xffip" maxlength="15"
-								data-invertvalue="false" data-prefname="extensions.agentSpoof.xffip"><br>
-			</div>
-
-						<div class="ddright">
-								<input type="checkbox" id="via" data-invertvalue="false" data-prefname="extensions.agentSpoof.via"/>
-								<label for="via" data-l10n-id="via_header_id"></label>
-								<span class="ddspan">
-							<select class="ipdropdown" id="viadd" data-prefname="extensions.agentSpoof.viadd" data-uipref="customvia">
-												<option value="random"	data-l10n-id="random_ip_id" ></option>
-												<option value="custom"	data-l10n-id="custom_ip_id" ></option>
-							</select>
-								</span>
-								<br>
-						</div>
-
-						<div id="customvia" class="hidden">
-				<label for="viaip" class="iplabel" data-l10n-id="via_ip_id"></label><input type="text" id="viaip" maxlength="15"
-								data-invertvalue="false" data-prefname="extensions.agentSpoof.viaip"><br>
-			</div>
-
-						<div class="ddright">
-
-								<label for="refdd"	data-l10n-id="referer_header_id"></label>
-
-								<span class="ddspan">
-										<select id="refdd" class="dd" data-prefname="extensions.agentSpoof.referer">
-												<option value="none" data-l10n-id="none_id"></option>
-												<option value="default" data-l10n-id="default_id"></option>
-												<!--<option value="custom" data-l10n-id="custom_id"></option> -->
-										</select>
-								</span>
-								<br>
-						</div>
-
-			<hr>
-
-						<div align="center" data-l10n-id="accept_header_info_id"></div>
-
-						<input type="checkbox" id="acceptd" data-raspref="extensions.agentSpoof.acceptDefault"
-						data-ffheader="network.http.accept.default"/>
-						<label for="acceptd" data-l10n-id="acceptd_id"></label><br>
-
-						<input type="checkbox" id="accepte"data-raspref="extensions.agentSpoof.acceptEncoding"
-						data-ffheader="network.http.accept-encoding"/>
-						<label for="accepte" data-l10n-id="accepte_id"></label><br>
-
-						<input type="checkbox" id="acceptl"data-raspref="extensions.agentSpoof.acceptLang"
-						data-ffheader="intl.accept_languages"/>
-						<label for="acceptl" data-l10n-id="acceptl_id"></label><br>
-
-				</div>
-
-				<div id="whitelist_tab_content" class="hidden">
-						<div align ="center"><b data-l10n-id="whitelist_option_id"></b></div>
-
-						<input type="checkbox" id="whitelist_disabled" data-invertvalue="false"
-								data-prefname="extensions.agentSpoof.whiteListDisabled"/>
-						<label for="whitelist_disabled" data-l10n-id="disable_whitelist_id"></label><br>
-						<hr>
-						<div id="wl_prof_expand">
-								<span id="whitelist_profile_title" data-l10n-id="whitelist_profile_id"></span>
-								<span id="wl_prof_title_span">+</span>
-						</div>
-
-						<div id="whitelist_profile" class="hidden">
-								User Agent: <input type="text" id="useragent_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListUserAgent"><br>
-								AppCodeName: <input type="text" id="appcodename_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListAppCodeName"><br>
-								AppName: <input type="text" id="appname_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListAppName"><br>
-								AppVersion: <input type="text" id="appversion_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListAppVersion"br>
-								Vendor: <input type="text" id="vendor_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListVendor"><br>
-								VendorSub: <input type="text" id="vendorsub_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListVendorSub"><br>
-								Platform: <input type="text" id="platform_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListPlatform"><br>
-								OsCpu: <input type="text" id="oscpu_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListOsCpu"><br>
-								Accept Default: <input type="text" id="acceptdefault_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListAccept"><br>
-								Accept Encoding: <input type="text" id="acceptencoding_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListAcceptEncoding"><br>
-								Accept Language: <input type="text" id="acceptlanguage_input" class="wl_prof"
-										data-prefname="extensions.agentSpoof.whiteListAcceptLanguage"><br>
-								<button type="button" id="wlprofsavebtn" data-l10n-id="save_wl_profile_id"></button>
-						</div>
-
-
-
-						<div id="wl_rules_expand">
-								<span id="whitelist_rules_title"data-l10n-id="add_whitelist_here_id"></span>
-								<span id="wl_rules_title_span">+</span>
-						</div>
-						<textarea id="site_whitelist" class="hidden"></textarea>
-				</div>
-
-				<div id="help_tab_content" class="hidden">
-
-
-						<h2>Random Agent Spoofer</h2>
-
-						<p class="version">0.9.5.2</p>
-
-								<!--Use customlink class to force loading of link in new tabs and not inside RAS's panel-->
-						<p>
-								Random Agent Spoofer is developed by <span class="customlink" data-url="https://github.com/dillbyrne/">dillbyrne</span> and
-								<span class="customlink"
-								data-url="https://github.com/dillbyrne/random-agent-spoofer/graphs/contributors">contributors</span>.
-								It is <em>free</em> (as in freedom) software distributed under GPLv3 license.
-						</p>
-
-						<h3>Code</h3>
-
-						<ul>
-								<li><div class="customlink"
-										data-url="https://github.com/dillbyrne/random-agent-spoofer/">Source code
-								</div></li>
-								<li><div class="customlink"
-										data-url="https://github.com/dillbyrne/random-agent-spoofer/labels/bug">Report problems
-								</div></li>
-						</ul>
-
-						<h3>Community</h3>
-
-						<ul>
-								<li><div class="customlink"
-										data-url="https://github.com/dillbyrne/random-agent-spoofer/wiki">Wiki
-								</div></li>
-								<li><div class="customlink"
-										data-url="https://github.com/dillbyrne/random-agent-spoofer/wiki/User-Manual">User manual
-								</div></li>
-								<li><div class="customlink"
-										data-url="https://github.com/dillbyrne/random-agent-spoofer/labels/enhancement">Suggest improvements
-								</div></li>
-						</ul>
-				</div>
-
-		</body>
+<head>
+	<meta charset="utf-8">
+
+	<link rel="stylesheet" type="text/css" media="all" href="../css/style.css"/>
+	<script src="optionspage.js" type="text/javascript"></script>
+</head>
+
+<body>
+
+<!-- Navigation tabs -->
+
+<div id="tabs_container">
+	<ul id="tabs">
+		<li><span id="ua_tab" class="selected" data-l10n-id="profile_tab_id"></span></li><!--
+	 --><li><span id="headers_tab" class="nonselected" data-l10n-id="headers_tab_id"></span></li><!--
+	 --><li><span id="extras_tab" class="nonselected" data-l10n-id="extras_tab_id"></span></li><!--
+	 --><li><span id="whitelist_tab" class="nonselected" data-l10n-id="whitelist_tab_id"></span></li><!--
+	 --><li><span id="help_tab" class="nonselected" data-l10n-id="help_tab_id"></span></li>
+	</ul>
+</div>
+
+<!-- Content of the "profile" tab -->
+
+<div id="ua_tab_content" class="tabContent">
+	<div id="top_profile_radios">
+		<ul>
+			<li>
+				<input type="radio" name="ua" id="default" value="default" />
+				<label for="default" data-l10n-id="real_id"></label>
+			</li><!--
+		 --><li>
+				<input type="radio" name="ua" id="random_desktop" value="random_desktop" />
+				<label for="random_desktop" data-l10n-id="random_desktop_id"></label>
+			</li><!--
+		 --><li>
+				<input type="radio" name="ua" id="random" value="random" />
+				<label for="random" data-l10n-id="random_id"></label>
+			</li><!--
+		 --><li>
+				<input type="radio" name="ua" id="random_mobile" value="random_mobile" />
+				<label for="random_mobile" data-l10n-id="random_mobile_id"></label>
+			</li>
+		</ul>
+	</div>
+
+	<div id="time_interval_display" class="hidden">
+		<span data-l10n-id="change_on_timer_id"></span>
+
+		<select id="timerdd">
+			<option value="none" data-l10n-id="no_timer_id"></option>
+			<option value="randomTime" data-l10n-id="random_id"></option>
+			<option value="request" data-l10n-id="per_request_id"></option>
+			<option value="1" data-l10n-id="1_min_id"></option>
+			<option value="5" data-l10n-id="5_mins_id"></option>
+			<option value="10" data-l10n-id="10_mins_id"></option>
+			<option value="20" data-l10n-id="20_mins_id"></option>
+			<option value="30" data-l10n-id="30_mins_id"></option>
+			<option value="40" data-l10n-id="40_mins_id"></option>
+			<option value="50" data-l10n-id="50_mins_id"></option>
+			<option value="60" data-l10n-id="60_mins_id"></option>
+		</select>
+	</div>
+
+	<div id="ualist"></div>
+</div>
+
+<!-- Content of the "headers" tab -->
+
+<div id="headers_tab_content" class="hidden">
+	<div align ="center"><b data-l10n-id="header_options_id"></b></div>
+
+	<input type="checkbox" id="auth" data-invertvalue="false" data-prefname="extensions.agentSpoof.authorization" />
+	<label for="auth" data-l10n-id="disable_auth_header_id"></label>
+	<br>
+
+	<input type="checkbox" id="dnt" data-invertvalue="false" data-prefname="privacy.donottrackheader.enabled" />
+	<label for="dnt" data-l10n-id="dnt_header_id" ></label>
+	<br>
+
+	<input type="checkbox" id="ifnone" data-invertvalue="false" data-prefname="extensions.agentSpoof.ifnone" />
+	<label for="ifnone" data-l10n-id="if_none_header_id"></label>
+	<br>
+
+	<div class="ddright">
+		<input type="checkbox" id="xff" data-invertvalue="false" data-prefname="extensions.agentSpoof.xff" />
+		<label for="xff" data-l10n-id="xff_header_id"></label>
+
+		<span class="ddspan">
+			<select class="ipdropdown" id="xffdd" data-prefname="extensions.agentSpoof.xffdd" data-uipref="customxff">
+				<option value="random" data-l10n-id="random_ip_id"></option>
+				<option value="custom" data-l10n-id="custom_ip_id"></option>
+			</select>
+		</span>
+
+		<br>
+	</div>
+
+	<div id="customxff" class="hidden">
+		<label for="xffip" class="iplabel" data-l10n-id="xff_ip_id"></label>
+		<input type="text" id="xffip" maxlength="15" data-invertvalue="false" data-prefname="extensions.agentSpoof.xffip" />
+		<br>
+	</div>
+
+	<div class="ddright">
+		<input type="checkbox" id="via" data-invertvalue="false" data-prefname="extensions.agentSpoof.via" />
+		<label for="via" data-l10n-id="via_header_id"></label>
+
+		<span class="ddspan">
+			<select class="ipdropdown" id="viadd" data-prefname="extensions.agentSpoof.viadd" data-uipref="customvia">
+				<option value="random" data-l10n-id="random_ip_id" ></option>
+				<option value="custom" data-l10n-id="custom_ip_id" ></option>
+			</select>
+		</span>
+
+		<br>
+	</div>
+
+	<div id="customvia" class="hidden">
+		<label for="viaip" class="iplabel" data-l10n-id="via_ip_id"></label>
+		<input type="text" id="viaip" maxlength="15" data-invertvalue="false" data-prefname="extensions.agentSpoof.viaip">
+		<br>
+	</div>
+
+	<div class="ddright">
+		<label for="refdd" data-l10n-id="referer_header_id"></label>
+
+		<span class="ddspan">
+			<select id="refdd" class="dd" data-prefname="extensions.agentSpoof.referer">
+				<option value="none" data-l10n-id="none_id"></option>
+				<option value="default" data-l10n-id="default_id"></option>
+				<!-- <option value="custom" data-l10n-id="custom_id"></option> -->
+			</select>
+		</span>
+
+		<br>
+	</div>
+
+	<hr>
+
+	<div align="center" data-l10n-id="accept_header_info_id"></div>
+
+	<input type="checkbox" id="acceptd" data-raspref="extensions.agentSpoof.acceptDefault" data-ffheader="network.http.accept.default" />
+	<label for="acceptd" data-l10n-id="acceptd_id"></label>
+	<br>
+
+	<input type="checkbox" id="accepte"data-raspref="extensions.agentSpoof.acceptEncoding" data-ffheader="network.http.accept-encoding" />
+	<label for="accepte" data-l10n-id="accepte_id"></label>
+	<br>
+
+	<input type="checkbox" id="acceptl"data-raspref="extensions.agentSpoof.acceptLang" data-ffheader="intl.accept_languages" />
+	<label for="acceptl" data-l10n-id="acceptl_id"></label>
+	<br>
+</div>
+
+<!-- Content of the "extras" tab -->
+
+<div id="extras_tab_content" class="hidden">
+	<div align ="center"><b data-l10n-id="extra_privacy_options_id" ></b></div>
+
+	<div class="ddright">
+		<!-- <span data-l10n-id="tz_github_only_id"></span> -->
+
+		<label for="tzdd" data-l10n-id="tz_spoofing_id"></label>
+
+		<span class="ddspan">
+			<select id="tzdd" class="dd" data-prefname="extensions.agentSpoof.tzOffset">
+				<option value="default" data-l10n-id="default_id"></option>
+				<option value="random" data-l10n-id="random_id"></option>
+				<option value="12">-12:00</option>
+				<option value="11">-11:00</option>
+				<option value="10">-10:00</option>
+				<option value="9.5">-09:30</option>
+				<option value="9">-09:00</option>
+				<option value="8">-08:00</option>
+				<option value="7">-07:00</option>
+				<option value="6">-06:00</option>
+				<option value="5">-05:00</option>
+				<option value="4.5">-04:30</option>
+				<option value="4">-04:00</option>
+				<option value="3.5">-03:30</option>
+				<option value="3">-03:00</option>
+				<option value="2">-02:00</option>
+				<option value="1">-01:00</option>
+				<option value="0">00:00</option>
+				<option value="-1">+01:00</option>
+				<option value="-2">+02:00</option>
+				<option value="-3">+03:00</option>
+				<option value="-3.5">+03:30</option>
+				<option value="-4">+04:00</option>
+				<option value="-4.5">+04:30</option>
+				<option value="-5">+05:00</option>
+				<option value="-5.5">+05:30</option>
+				<option value="-5.75">+05:45</option>
+				<option value="-6">+06:00</option>
+				<option value="-6.5">+06:30</option>
+				<option value="-7">+07:00</option>
+				<option value="-8">+08:00</option>
+				<option value="-8.75">+08:45</option>
+				<option value="-9">+09:00</option>
+				<option value="-9.5">+09:30</option>
+				<option value="-10">+10:00</option>
+				<option value="-10.5">+10:30</option>
+				<option value="-11">+11:00</option>
+				<option value="-11.5">+11:30</option>
+				<option value="-12">+12:00</option>
+				<option value="-12.75">+12:45</option>
+				<option value="-13">+13:00</option>
+				<option value="-14">+14:00</option>
+			</select>
+		</span>
+
+		<br>
+	</div>
+
+	<div class="ddright">
+		<!-- </span data-l10n-id="screen_github_only_id" ></span> -->
+
+		<label for="screendd" data-l10n-id="screen_spoofing_id" ></label>
+
+		<span class="ddspan">
+			<select id="screendd" class="dd" data-prefname="extensions.agentSpoof.screenSize">
+				<option value="default" data-l10n-id="default_id"></option>
+				<option value="random" data-l10n-id="random_id"></option>
+				<option value="profile" data-l10n-id="profile_id"></option>
+				<option value="800x600">800x600</option>
+				<option value="1024x600">1024x600</option>
+				<option value="1024x768">1024x768</option>
+				<option value="1152x864">1152x864</option>
+				<option value="1280x720">1280x720</option>
+				<option value="1280x768">1280x768</option>
+				<option value="1280x800">1280x800</option>
+				<option value="1280x960">1280x960</option>
+				<option value="1280x1024">1280x1024</option>
+				<option value="1360x768">1360x768</option>
+				<option value="1366x768">1366x768</option>
+				<option value="1440x900">1440x900</option>
+				<option value="1400x1050">1400x1050</option>
+				<option value="1600x900">1600x900</option>
+				<option value="1600x1200">1600x1200</option>
+				<option value="1680x1050">1680x1050</option>
+				<option value="1920x1080">1920x1080</option>
+				<option value="1920x1200">1920x1200</option>
+				<option value="2048x1152">2048x1152</option>
+				<option value="2560x1440">2560x1440</option>
+				<option value="2560x1600">2560x1600</option>
+			</select>
+		</span>
+
+		<br>
+	</div>
+
+	<input type="checkbox" id="winname"data-invertvalue="false" data-prefname="extensions.agentSpoof.windowName" />
+	<label for="winname" data-l10n-id="protect_window_name_id"></label>
+	<br>
+
+	<input type="checkbox" id="canvas" data-invertvalue="false" data-prefname="extensions.agentSpoof.canvas" />
+	<label for="canvas" data-l10n-id="disable_canvas_support_id"></label>
+	<br>
+
+	<input type="checkbox" id="fonts" />
+	<label for="fonts" data-l10n-id="use_standard_font_id"></label>
+	<br>
+
+	<input type="checkbox"id="dom" data-invertvalue="true" data-prefname="dom.storage.enabled" />
+	<label for="dom" data-l10n-id="disable_local_dom_storage_id"></label>
+	<br>
+
+	<input type="checkbox" id="tab_history" data-invertvalue="false" data-prefname="extensions.agentSpoof.limitTab" />
+	<label for="tab_history" data-l10n-id="limit_tab_history_id"></label>
+	<br>
+
+	<input type="checkbox" id="browsing_downloads" data-invertvalue="true" data-prefname="places.history.enabled" />
+	<label for="browsing_downloads" data-l10n-id="disable_browsing_history_id"></label>
+	<br>
+
+	<input type="checkbox" id="cache_memory" data-invertvalue="true" data-prefname="browser.cache.memory.enable" />
+	<label for="cache_memory" data-l10n-id="disable_memory_cache_id"></label>
+	<br>
+
+	<input type="checkbox" id="cache_disk" data-invertvalue="true" data-prefname="browser.cache.disk.enable" />
+	<label for="cache_disk" data-l10n-id="disable_disk_cache_id"></label>
+	<br>
+
+	<input type="checkbox" id="cache_network" data-invertvalue="true" data-prefname="network.http.use-cache" />
+	<label for="cache_network" data-l10n-id="disable_network_cache_id"></label>
+	<br>
+
+	<input type="checkbox" id="geo" data-invertvalue="true" data-prefname="geo.enabled" />
+	<label for="geo" data-l10n-id="disable_geolocation_id"></label>
+	<br>
+
+	<input type="checkbox" id="link" data-invertvalue="true" data-prefname="network.prefetch-next" />
+	<label for="link" data-l10n-id="disable_link_prefetching_id"></label>
+	<br>
+
+	<input type="checkbox" id="dns" data-invertvalue="false" data-prefname="network.dns.disablePrefetch" />
+	<label for="dns" data-l10n-id="disable_dns_prefetching_id"></label>
+	<br>
+
+	<input type="checkbox" id="webgl" data-invertvalue="false" data-prefname="webgl.disabled" />
+	<label for="webgl" data-l10n-id="disable_webgl_id"></label>
+	<br>
+
+	<input type="checkbox" id="webrtc" data-invertvalue="true" data-prefname="media.peerconnection.enabled" />
+	<label for="webrtc" data-l10n-id="disable_webrtc_id"></label>
+	<br>
+
+	<input type="checkbox" id="pdfjs" data-invertvalue="false" data-prefname="pdfjs.disabled" />
+	<label for="pdfjs" data-l10n-id="disable_pdfjs_id"></label>
+	<br>
+
+	<input type="checkbox" id="search_suggest" data-invertvalue="true" data-prefname="browser.search.suggest.enabled" />
+	<label for="search_suggest" data-l10n-id="disable_search_suggestions_id"></label>
+	<br>
+
+	<input type="checkbox" id="dom_performance" data-invertvalue="true" data-prefname="dom.enable_performance" />
+	<label for="dom_performance" data-l10n-id="dom_performance_id"></label>
+	<br>
+
+	<input type="checkbox" id="dom_battery" data-invertvalue="true" data-prefname="dom.battery.enabled" />
+	<label for="dom_battery" data-l10n-id="dom_battery_id"></label>
+	<br>
+
+	<input type="checkbox" id="dom_gamepad" data-invertvalue="true" data-prefname="dom.gamepad.enabled" />
+	<label for="dom_gamepad" data-l10n-id="dom_gamepad_id"></label>
+	<br>
+
+	<input type="checkbox" id="clicktoplay" data-invertvalue="false" data-prefname="plugins.click_to_play" />
+	<label for="clicktoplay" data-l10n-id="click_to_play_id"></label>
+	<br>
+
+	<input type="checkbox" id="mixed_content_active" data-invertvalue="false" data-prefname="security.mixed_content.block_active_content" />
+	<label for="mixd_content_active" data-l10n-id="mixed_content_active_id"></label>
+	<br>
+
+	<input type="checkbox" id="mixed_content_display" data-invertvalue="false" data-prefname="security.mixed_content.block_display_content" />
+	<label for="mixed_content_display" data-l10n-id="mixed_content_display_id"></label>
+	<br>
+</div>
+
+<!-- Content of the "whitelist" tab -->
+
+<div id="whitelist_tab_content" class="hidden">
+	<div align ="center"><b data-l10n-id="whitelist_option_id"></b></div>
+
+	<input type="checkbox" id="whitelist_disabled" data-invertvalue="false" data-prefname="extensions.agentSpoof.whiteListDisabled" />
+	<label for="whitelist_disabled" data-l10n-id="disable_whitelist_id"></label>
+	<br>
+
+	<hr>
+
+	<div id="wl_prof_expand">
+		<span id="whitelist_profile_title" data-l10n-id="whitelist_profile_id"></span>
+		<span id="wl_prof_title_span">+</span>
+	</div>
+
+	<div id="whitelist_profile" class="hidden">
+		User Agent:
+		<input type="text" id="useragent_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListUserAgent" />
+		<br>
+
+		AppCodeName:
+		<input type="text" id="appcodename_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListAppCodeName" />
+		<br>
+
+		AppName:
+		<input type="text" id="appname_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListAppName" />
+		<br>
+
+		AppVersion:
+		<input type="text" id="appversion_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListAppVersion" />
+		<br>
+
+		Vendor:
+		<input type="text" id="vendor_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListVendor" />
+		<br>
+
+		VendorSub:
+		<input type="text" id="vendorsub_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListVendorSub" />
+		<br>
+
+		Platform:
+		<input type="text" id="platform_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListPlatform" />
+		<br>
+
+		OsCpu:
+		<input type="text" id="oscpu_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListOsCpu" />
+		<br>
+
+		Accept Default:
+		<input type="text" id="acceptdefault_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListAccept" />
+		<br>
+
+		Accept Encoding:
+		<input type="text" id="acceptencoding_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListAcceptEncoding" />
+		<br>
+
+		Accept Language:
+		<input type="text" id="acceptlanguage_input" class="wl_prof" data-prefname="extensions.agentSpoof.whiteListAcceptLanguage" />
+		<br>
+
+		<button type="button" id="wlprofsavebtn" data-l10n-id="save_wl_profile_id"></button>
+	</div>
+
+	<div id="wl_rules_expand">
+		<span id="whitelist_rules_title"data-l10n-id="add_whitelist_here_id"></span>
+		<span id="wl_rules_title_span">+</span>
+	</div>
+
+	<textarea id="site_whitelist" class="hidden"></textarea>
+</div>
+
+<!-- Content of the "help" tab -->
+
+<div id="help_tab_content" class="hidden">
+	<h2>Random Agent Spoofer</h2>
+
+	<p class="version">0.9.5.2</p>
+
+	<!--Use customlink class to force loading of link in new tabs and not inside RAS's panel-->
+	<p>
+		Random Agent Spoofer is developed by <span class="customlink" data-url="https://github.com/dillbyrne/">dillbyrne</span> and
+		<span class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/graphs/contributors">contributors</span>.
+		It is <em>free</em> (as in freedom) software distributed under GPLv3 license.
+	</p>
+
+	<h3>Code</h3>
+
+	<ul>
+		<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/">Source code</div></li>
+		<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/labels/bug">Report problems</div></li>
+	</ul>
+
+	<h3>Community</h3>
+
+	<ul>
+		<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/wiki">Wiki</div></li>
+		<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/wiki/User-Manual">User manual</div></li>
+		<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/labels/enhancement">Suggest improvements</div></li>
+	</ul>
+</div>
+
+</body>
 </html>

--- a/data/js/optionspage.js
+++ b/data/js/optionspage.js
@@ -137,7 +137,7 @@ document.body.addEventListener("click",function(e) {
 
     	}else{
     		document.getElementById("whitelist_profile").className = "";
-    		document.getElementById("wl_prof_title_span").textContent = "-";
+    	  	document.getElementById("wl_prof_title_span").textContent = "–";
     	}
 
     }else if(e.target.id =="wl_rules_expand" || e.target.id =="whitelist_rules_title" 
@@ -149,7 +149,7 @@ document.body.addEventListener("click",function(e) {
 
     	}else{
     	  	document.getElementById("site_whitelist").className = "";
-    	  	document.getElementById("wl_rules_title_span").textContent = "-";
+    	  	document.getElementById("wl_rules_title_span").textContent = "–";
     	}
 
     }else if(e.target.className == "customlink"){
@@ -212,6 +212,7 @@ function toggleList(innerListElementId) {
 	if (innerlistElement.style.display == "none"){
 		innerlistElement.style.display = "block";
 		innerlistElement.style.margin = "1em 0";
+		text.textContent = "–";
 	}else{
 		innerlistElement.style.display = "none";
 		text.textContent = "+";

--- a/data/js/optionspage.js
+++ b/data/js/optionspage.js
@@ -211,7 +211,7 @@ function toggleList(innerListElementId) {
 	//toggle the child list and parents assiociated indicator
 	if (innerlistElement.style.display == "none"){
 		innerlistElement.style.display = "block";
-		text.textContent = "-";
+		innerlistElement.style.margin = "1em 0";
 	}else{
 		innerlistElement.style.display = "none";
 		text.textContent = "+";

--- a/data/js/optionspage.js
+++ b/data/js/optionspage.js
@@ -1,20 +1,20 @@
 document.body.addEventListener("change", function(e) {
- 
+
 	//get selected checkbox
 	if (e.target.type == "checkbox" && e.target.className != "excludecb"){
-		
+
 		if(e.target.dataset.invertvalue == "false")
 			self.port.emit("setPrefValue",e.target.dataset.prefname,e.target.checked);
 
-		else if(e.target.dataset.invertvalue == "true") 
+		else if(e.target.dataset.invertvalue == "true")
 			self.port.emit("setPrefValue",e.target.dataset.prefname,!(e.target.checked));
-		
+
 		else if(e.target.dataset.ffheader) // is it an accept header ?
 			self.port.emit("setAcceptHeader",e.target.dataset.raspref,e.target.dataset.ffheader,e.target.checked);
 
-		else //call a specific function for this checkbox 
+		else //call a specific function for this checkbox
 			self.port.emit(e.target.id,e.target.checked);
-	} 
+	}
 	else if(e.target.className == "excludecb"){
 		self.port.emit("excludecb",e.target.id,e.target.value,e.target.checked);
 	}
@@ -22,31 +22,31 @@ document.body.addEventListener("change", function(e) {
 
 		if (e.target[e.target.selectedIndex].value == "custom")
 			document.getElementById(e.target.dataset.uipref).className="";
-		else 
+		else
 			document.getElementById(e.target.dataset.uipref).className="hidden";
-		
+
 		self.port.emit("setPrefValue",e.target.dataset.prefname,e.target[e.target.selectedIndex].value);
-	} 
+	}
 	else if(e.target.className == "dd"){
 		self.port.emit("setPrefValue",e.target.dataset.prefname,e.target[e.target.selectedIndex].value);
 	}
 	else if (e.target.id == "timerdd" || e.target.name == "ua") {
-    
+
 		//get timer and selected ua option
 		var timerdd = document.getElementById("timerdd");
 		var uaList = document.getElementsByName("ua");
 		var time = timerdd[timerdd.selectedIndex].value;
 
 		//get selected profile
-		var ua_choice =  document.querySelector('input[name = "ua"]:checked').value;
+		var ua_choice = document.querySelector('input[name = "ua"]:checked').value;
 		self.port.emit("uachange",ua_choice,time);
-	}	
+	}
 
 },false);
 
 
 document.body.addEventListener("keyup", function(e) {
- 
+
 	//set the input validation class
 	if ((e.target.id).substr(3,2) == "ip"){
 		var input =  document.getElementById(e.target.id);
@@ -58,7 +58,7 @@ document.body.addEventListener("keyup", function(e) {
 			input.className = "validInput";
 			self.port.emit("setPrefValue",e.target.dataset.prefname,input.value);
 		}
-			
+
 	}else 	if (e.target.id == "site_whitelist"){
 		var input =  document.getElementById(e.target.id);
 
@@ -71,28 +71,28 @@ document.body.addEventListener("keyup", function(e) {
 
 			var data = JSON.parse(document.getElementById("site_whitelist").value);
 
-		    //sort the json data by url attribute
-		    data = sortWhiteListObjByURL(data);
+			//sort the json data by url attribute
+			data = sortWhiteListObjByURL(data);
 
-		    //copy the urls into another list for faster lookups
-		    var sitelist = new Array();
+			//copy the urls into another list for faster lookups
+			var sitelist = new Array();
 
-		    for(var i=0; i<data.length; i++){
-		        sitelist.push(data[i].url);
-		    }
+			for(var i=0; i<data.length; i++){
+				sitelist.push(data[i].url);
+			}
 
-		    //save the lists
-		    self.port.emit("whitelist","siteWhiteList",JSON.stringify(data),sitelist.toString());
-		}	
-	}    
+			//save the lists
+			self.port.emit("whitelist","siteWhiteList",JSON.stringify(data),sitelist.toString());
+		}
+	}
 
 },false);
 
 //handle whitelist
 document.body.addEventListener("click",function(e) {
-	
+
 	//whitelist profile save button
-    if(e.target.id =="wlprofsavebtn"){
+	if(e.target.id =="wlprofsavebtn"){
 
 		self.port.emit("setPrefValue",
 			document.getElementById("useragent_input").dataset.prefname,
@@ -128,39 +128,39 @@ document.body.addEventListener("click",function(e) {
 			document.getElementById("acceptlanguage_input").dataset.prefname,
 			document.getElementById("acceptlanguage_input").value);
 
-    }else if(e.target.id =="wl_prof_expand" || e.target.id == "whitelist_profile_title" 
-    	|| e.target.id == "wl_prof_title_span"){
-    	
-    	if(document.getElementById("whitelist_profile").className == ""){
-    		document.getElementById("whitelist_profile").className = "hidden";
-    		document.getElementById("wl_prof_title_span").textContent = "+";
+	}else if(e.target.id =="wl_prof_expand" || e.target.id == "whitelist_profile_title"
+		|| e.target.id == "wl_prof_title_span"){
 
-    	}else{
-    		document.getElementById("whitelist_profile").className = "";
-    	  	document.getElementById("wl_prof_title_span").textContent = "–";
-    	}
+		if(document.getElementById("whitelist_profile").className == ""){
+			document.getElementById("whitelist_profile").className = "hidden";
+			document.getElementById("wl_prof_title_span").textContent = "+";
 
-    }else if(e.target.id =="wl_rules_expand" || e.target.id =="whitelist_rules_title" 
-    	|| e.target.id == "wl_rules_title_span"){
+		}else{
+			document.getElementById("whitelist_profile").className = "";
+			document.getElementById("wl_prof_title_span").textContent = "–";
+		}
 
-    	if(document.getElementById("site_whitelist").className == ""){
-    		document.getElementById("site_whitelist").className = "hidden";
-    		document.getElementById("wl_rules_title_span").textContent = "+";
+	}else if(e.target.id =="wl_rules_expand" || e.target.id =="whitelist_rules_title"
+		|| e.target.id == "wl_rules_title_span"){
 
-    	}else{
-    	  	document.getElementById("site_whitelist").className = "";
-    	  	document.getElementById("wl_rules_title_span").textContent = "–";
-    	}
+		if(document.getElementById("site_whitelist").className == ""){
+			document.getElementById("site_whitelist").className = "hidden";
+			document.getElementById("wl_rules_title_span").textContent = "+";
 
-    }else if(e.target.className == "customlink"){
-    	self.port.emit("customlink",e.target.dataset.url);
-    }
+		}else{
+			document.getElementById("site_whitelist").className = "";
+			document.getElementById("wl_rules_title_span").textContent = "–";
+		}
+
+	}else if(e.target.className == "customlink"){
+		self.port.emit("customlink",e.target.dataset.url);
+	}
 
 },false);
 
 
 document.body.addEventListener("focus", function(e) {
- 
+
 	//set the input validation class
 	if ((e.target.id).substr(3,2) == "ip"){
 		var input =  document.getElementById(e.target.id);
@@ -170,7 +170,7 @@ document.body.addEventListener("focus", function(e) {
 			input.className = "invalidInput";
 		else
 			input.className = "validInput";
-			
+
 	}else if(e.target.id == "site_whitelist"){
 
 		var input =  document.getElementById(e.target.id);
@@ -188,25 +188,25 @@ document.body.addEventListener("focus", function(e) {
 
 
 document.body.addEventListener("blur", function(e) {
- 
+
 	//remove the class for input validation
 	if ((e.target.id).substr(3,2) == "ip"){
 		document.getElementById(e.target.id).className = "";
 	}else if(e.target.id == "site_whitelist"){
 		document.getElementById(e.target.id).className = "";
-	}  
+	}
 
 },true);
 
 
 function toggleList(innerListElementId) {
-  
+
 	var innerlistElement = document.getElementById(innerListElementId);
-	  
-	//get the span of the parent li 
+
+	//get the span of the parent li
 	//it's index is the same as it's child list, so we can get it from that
-	var text = document.getElementById("li_text"+ innerListElementId.replace( /^\D+/g, '')); 
-	var excludeText = document.getElementById("li_exclude_text"+ innerListElementId.replace( /^\D+/g, '')); 
+	var text = document.getElementById("li_text"+ innerListElementId.replace( /^\D+/g, ''));
+	var excludeText = document.getElementById("li_exclude_text"+ innerListElementId.replace( /^\D+/g, ''));
 
 	//toggle the child list and parents assiociated indicator
 	if (innerlistElement.style.display == "none"){
@@ -223,7 +223,7 @@ function changeTab(selected_tab,tabs){
 
 	for (var i =0; i< tabs.length;i++){
 		if (tabs[i].children[0].id == selected_tab.id){
-      
+
 			var selected = document.getElementById(selected_tab.id+"_content");
 			selected.className = "tabContent";
 			selected_tab.className = "selected";
@@ -231,8 +231,8 @@ function changeTab(selected_tab,tabs){
 		}else{
 			var non_selected = document.getElementById(tabs[i].children[0].id+"_content");
 			non_selected.className = "hidden";
-			tabs[i].children[0].className = "nonselected"; 
-		} 
+			tabs[i].children[0].className = "nonselected";
+		}
 	}
 }
 
@@ -240,22 +240,22 @@ function validateIP(ipaddress){
 
 	if(ipaddress === null || ipaddress == "")
 		return false;
-	
+
 	var ip_segments = ipaddress.split(".");
-	
+
 	//check for 4 segments split on "."
 	if(ip_segments.length != 4){
 		return false;
 	}else{
-		
+
 		for (var i=0; i<4; i++){
 			//check if ip segment is a number and not a hex number or a space or an exponent
 			if( (!isNaN(ip_segments[i])) && ip_segments[i].indexOf('x') == -1 && ip_segments[i].length > 0
 					&& ip_segments[i].length <= 3 && ip_segments[i].indexOf(' ') == -1 && ip_segments[i].indexOf('e') == -1 ){
-				
+
 				//check the range of the segment is valid
 				if(ip_segments[i] >=0 && ip_segments[i] <= 255 ){
-					
+
 					//check for 000 , 010 etc
 					if ((ip_segments[i].substring(0,1) == "0" && ip_segments[i] != 0) || ip_segments[i] == "00" || ip_segments[i] == "000")
 						return false;
@@ -264,7 +264,7 @@ function validateIP(ipaddress){
 				}
 			}else{
 				return false;
-			}		
+			}
 		}
 	}
 	return true;
@@ -273,7 +273,7 @@ function validateIP(ipaddress){
 function validateJSON(jsonStringData){
 	try{
 		var data = JSON.parse(jsonStringData);
-		
+
 		if (data.length == 0)
 			return false;
 
@@ -282,7 +282,7 @@ function validateJSON(jsonStringData){
 			if (data[i].url == "" || data[i].url === undefined)
 				return false;
 		}
-		
+
 		return true;
 
 	}catch(e){
@@ -295,11 +295,11 @@ function sortWhiteListObjByURL(array){
 	var array = array.sort(function(a,b){
 
 		if(a.url == b.url)
-		    return 0;
+			return 0;
 		if(a.url < b.url)
-		    return -1;
+			return -1;
 		if(a.url > b.url)
-		    return 1;
+			return 1;
 		});
 
 	return array;


### PR DESCRIPTION
### Updated/cleaned up CSS

Cleaned up the CSS to ease future updates: commented the code, regrouped rules, deleted redundant and or useless properties, alphabetically re-ordered properties when needed,...

Slightly updated some styles.

### Removed useless hr element

Self-explanatory.

### Removed useless whitespace before attribute

Self-explanatory.

### Replaced dash character by "en dash"

Replaced "-" by "–" as the "collapse" symbol. It is larger, therefore more visible.

### Fixed whitespace/tab mixing, cleaned line endings, added new line at the end of file

Self-explanatory.

### Removed useless whitespaces among attributes

Self-explanatory.

### Fixed whitespace/tab mixing, fixed markup, fixed indentation, commented the code

This file was a complete mess - to say the least. Fixed a series of problems regarding whitespace/tab mixing and homogenized the markup to ease future updates.