### PR TITLE
Replaced custom rules for links by a "a" element with a target attribute set to "_blank"

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -240,9 +240,3 @@ h2,
 #version {
 	text-align: center;
 }
-
-.customlink {
-	color:	blue;
-	cursor: pointer;
-	text-decoration: underline;
-}

--- a/data/html/options-panel.html
+++ b/data/html/options-panel.html
@@ -428,26 +428,25 @@
 
 			<p id="version"></p>
 
-			<!--Use customlink class to force loading of link in new tabs and not inside RAS's panel-->
 			<p>
-				Random Agent Spoofer is developed by <span class="customlink" data-url="https://github.com/dillbyrne/">dillbyrne</span> and
-				<span class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/graphs/contributors">contributors</span>.
+				Random Agent Spoofer is developed by <a href="https://github.com/dillbyrne/" target="_blank">dillbyrne</a> and
+				<a href="https://github.com/dillbyrne/random-agent-spoofer/graphs/contributors" target="_blank">contributors</a>.
 				It is <em>free</em> (as in freedom) software distributed under GPLv3 license.
 			</p>
 
 			<h3>Code</h3>
 
 			<ul>
-				<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/">Source code</div></li>
-				<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/labels/bug">Report problems</div></li>
+				<li><a href="https://github.com/dillbyrne/random-agent-spoofer/" target="_blank">Source code</a></li>
+				<li><a href="https://github.com/dillbyrne/random-agent-spoofer/labels/bug" target="_blank">Report problems</a></li>
 			</ul>
 
 			<h3>Community</h3>
 
 			<ul>
-				<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/wiki">Wiki</div></li>
-				<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/wiki/User-Manual">User manual</div></li>
-				<li><div class="customlink" data-url="https://github.com/dillbyrne/random-agent-spoofer/labels/enhancement">Suggest improvements</div></li>
+				<li><a href="https://github.com/dillbyrne/random-agent-spoofer/wiki" target="_blank">Wiki</a></li>
+				<li><a href="https://github.com/dillbyrne/random-agent-spoofer/wiki/User-Manual" target="_blank">User manual</a></li>
+				<li><a href="https://github.com/dillbyrne/random-agent-spoofer/labels/enhancement" target="_blank">Suggest improvements</a></li>
 			</ul>
 		</div> <!-- End "Help" Tab Content-->
 

--- a/data/js/optionspage.js
+++ b/data/js/optionspage.js
@@ -177,8 +177,6 @@ document.body.addEventListener("click",function(e) {
     	  	document.getElementById("standard_extras_title_span").textContent = "–";
     	}
 
-    }else if(e.target.className == "customlink"){
-    	self.port.emit("customlink",e.target.dataset.url);
     }
 
 },false);


### PR DESCRIPTION
Fixes the issues of links being opened in RAS panel without requiring additional JS.