### PR TITLE
Set the "spoof" class on body rather than on a div, removed given div

### DIFF
--- a/data/html/options-panel.html
+++ b/data/html/options-panel.html
@@ -8,15 +8,13 @@
 
 <!-- Navigation tabs -->
 
-<div id="tabs_container">
-	<ul id="tabs">
-		<li><span id="ua_tab" class="selected" data-l10n-id="profile_tab_id"></span></li><!--
-	 --><li><span id="headers_tab" class="nonselected" data-l10n-id="headers_tab_id"></span></li><!--
-	 --><li><span id="extras_tab" class="nonselected" data-l10n-id="extras_tab_id"></span></li><!--
-	 --><li><span id="whitelist_tab" class="nonselected" data-l10n-id="whitelist_tab_id"></span></li><!--
-	 --><li><span id="help_tab" class="nonselected" data-l10n-id="help_tab_id"></span></li>
-	</ul>
-</div>
+<ul id="tabs">
+	<li><span id="ua_tab" class="selected" data-l10n-id="profile_tab_id"></span></li><!--
+	--><li><span id="headers_tab" class="nonselected" data-l10n-id="headers_tab_id"></span></li><!--
+	--><li><span id="extras_tab" class="nonselected" data-l10n-id="extras_tab_id"></span></li><!--
+	--><li><span id="whitelist_tab" class="nonselected" data-l10n-id="whitelist_tab_id"></span></li><!--
+	--><li><span id="help_tab" class="nonselected" data-l10n-id="help_tab_id"></span></li>
+</ul>
 
 <!-- "Profile" Tab Content -->
 

--- a/data/js/set-options.js
+++ b/data/js/set-options.js
@@ -222,9 +222,9 @@ function setTimerVisibility(ua_choice){
 function setTabsColors(ua_choice){
 
 	if(ua_choice != "default"){
-		document.getElementById("tabs_container").className ="spoof";
+		document.body.classList.add("spoof");
 	}else{
-		document.getElementById("tabs_container").className ="";
+		document.body.classList.remove("spoof");
 	}
 
 };


### PR DESCRIPTION
Started to get rid of the useless/redundant markup.

Started to use [classList](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) `add` and `remove` rather className to prepare for future updates.