### PR TITLE
Fix icon size when toggling state.

### DIFF
--- a/lib/ActionButton.js
+++ b/lib/ActionButton.js
@@ -35,12 +35,12 @@ exports.toggleIconAndLabel = function() {
 
 	if (PrefServ.getter('extensions.agentSpoof.uaChosen') != 'default') {
 
-		button.icon = Data.get('images/on64.png');
+		button.icon = Data.get('images/on.png');
 		button.label = labels[0];
 
 	} else {
 
-		button.icon = Data.get('images/off64.png');
+		button.icon = Data.get('images/off.png');
 		button.label = labels[1];
 	}
 };


### PR DESCRIPTION
Toggling also needs to use the smaller icon so the size remains stable.