### PR TITLE
Updated: Temporary Email

### DIFF
--- a/data/js/itemSelection.js
+++ b/data/js/itemSelection.js
@@ -46,7 +46,7 @@ function setupTempEmail(data, node) {
 	} else if (data === 'mail_mailinator') {
 
 		node.value = mailbox_id + '@mailinator.com';
-		url = 'https://www.mailinator.com/inbox2.jsp?to=' + mailbox_id;
+		url = 'https://www.mailinator.com/inbox2.jsp?public_to=' + mailbox_id;
 	}
 
 	return [data, url];

--- a/data/js/itemSelection.js
+++ b/data/js/itemSelection.js
@@ -28,14 +28,6 @@ function setupTempEmail(data, node) {
 		node.value=mailbox_id + '@anonbox.net';
 		url = 'https://anonbox.net/abx.html?url=' + mailbox_id;
 
-	} else if (data === 'mail_kozmail') {
-
-		//pick a server randomly
-		var server = ((Math.round(Math.random() * 10) + 1) % 2 == 0) ? '@ee1.pl' : '@ee2.pl';
-
-		node.value = mailbox_id + server;
-		url = 'http://www.koszmail.pl/koszmail/mailBox.php?box=' + mailbox_id + '&mailBoxAt=' + server;
-
 	} else if (data === 'mail_dispostable') {
 
 		node.value = mailbox_id + '@dispostable.com';

--- a/data/js/itemSelection.js
+++ b/data/js/itemSelection.js
@@ -46,7 +46,7 @@ function setupTempEmail(data, node) {
 	} else if (data === 'mail_mailinator') {
 
 		node.value = mailbox_id + '@mailinator.com';
-		url = 'https://www.mailinator.com/inbox.jsp?to=' + mailbox_id;
+		url = 'https://www.mailinator.com/inbox2.jsp?to=' + mailbox_id;
 	}
 
 	return [data, url];

--- a/lib/ContextMenu.js
+++ b/lib/ContextMenu.js
@@ -76,7 +76,6 @@ var email = cm.Menu({
 	context: cm.SelectorContext('input'),
 	items: [
 		cm.Item({ image: Data.get('images/email_item.png'), label: 'Anonbox', data: 'mail_anonbox' }),
-		cm.Item({ image: Data.get('images/email_item.png'), label: 'Kozmail', data: 'mail_kozmail' }),
 		cm.Item({ image: Data.get('images/email_item.png'), label: 'MailCatch', data: 'mail_mailcatch' }),
 		cm.Item({ image: Data.get('images/email_item.png'), label: 'Yopmail', data: 'mail_yopmail' }),
 		cm.Item({ image: Data.get('images/email_item.png'), label: 'Mailinator', data: 'mail_mailinator' }),


### PR DESCRIPTION
I have removed Koszmail.pl from the list of temporary emails as the server has been down for quite some time. I'm not entirely sure what happened or whether the service will make a comeback but have decided to remove the URL from RAS. 

I haven't found many other disposable email services that allow you to directly load the inbox using the URL + `mailbox_id.`. Therefore, nothing has been replaced.

I have also fixed the URL of "mailinator" as I was receiving the following message:

![mailintator](https://cloud.githubusercontent.com/assets/16097892/17047598/075f599e-5023-11e6-8b56-5e886075e87b.png)