### PR TITLE
Fix page break in "about:addons" via whitelist due to the latest changes

### DIFF
--- a/lib/PrefServ.js
+++ b/lib/PrefServ.js
@@ -178,7 +178,7 @@ exports.createPrefs = function() {
 		['extensions.agentSpoof.canvas', false],
 		['extensions.agentSpoof.blockPlugins', false],
 		['extensions.agentSpoof.fullWhiteList',
-			'[{"url": "addons.mozilla.org"}, {"url": "play.google.com"}, {"url": "youtube.com"}]'],
+			'[{"url":"about:addons","options":["plugins"]}, {"url": "addons.mozilla.org"}, {"url": "play.google.com"}, {"url": "youtube.com"}]'],
 		['extensions.agentSpoof.whiteListUserAgent','Mozilla/5.0 (Windows NT 6.2; rv:50.0) Gecko/20100101 Firefox/50.0'],
 		['extensions.agentSpoof.whiteListAppCodeName', 'Mozilla'],
 		['extensions.agentSpoof.whiteListAppName', 'Netscape'],

--- a/lib/PrefServ.js
+++ b/lib/PrefServ.js
@@ -178,7 +178,7 @@ exports.createPrefs = function() {
 		['extensions.agentSpoof.canvas', false],
 		['extensions.agentSpoof.blockPlugins', false],
 		['extensions.agentSpoof.fullWhiteList',
-			'[{"url":"about:addons","options":["plugins"]}, {"url": "addons.mozilla.org"}, {"url": "play.google.com"}, {"url": "youtube.com"}]'],
+			'[{"url": "about:addons","options":["plugins"]}, {"url": "addons.mozilla.org"}, {"url": "play.google.com"}, {"url": "youtube.com"}]'],
 		['extensions.agentSpoof.whiteListUserAgent','Mozilla/5.0 (Windows NT 6.2; rv:50.0) Gecko/20100101 Firefox/50.0'],
 		['extensions.agentSpoof.whiteListAppCodeName', 'Mozilla'],
 		['extensions.agentSpoof.whiteListAppName', 'Netscape'],


### PR DESCRIPTION
The script injection option "Block plugins" breaks the about:addons page in Firefox which limits the users ability to change plugin settings. This single default rule has been added to fix the issue: `{"url":"about:addons","options":["plugins"]}`

Screenshot:
![plugins](https://cloud.githubusercontent.com/assets/16097892/18737352/80a0fa48-80d3-11e6-9b07-64609b261a5a.jpeg)
