### PR TITLE
Adds regexp possibility to the whitelist

### DIFF
--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -1,13 +1,13 @@
 var PrefServ = require('./PrefServ');
 
 exports.defineProp = function(window, obj, prop, val) {
-	
+
 		Object.defineProperty(window.wrappedJSObject[obj].prototype,
 			prop,
 			{
 				enumerable: true,
 				configurable: false,
-				value: val	
+				value: val
 			});
 };
 
@@ -20,31 +20,37 @@ exports.getRandomNum = function (maximum) {
 //check if a url is in the list
 //if so whitelist options are checked for that url
 exports.listCheck = function (url, listStates) {
-	
+
 	//act as if there are no WL entries while the whitelist is disabled
 	if(PrefServ.getter('extensions.agentSpoof.whiteListDisabled')){
 		resetListStates(listStates);
 		return false;
 	}
-	
+
 	//prevent empty window urls from overriding the list states
 	if (url.length == 0)
 		return false;
-	
+
 	//reset the previous entries
-	resetListStates(listStates); 
+	resetListStates(listStates);
 
 
 
-	var wlist = JSON.parse(PrefServ.getter('extensions.agentSpoof.fullWhiteList'));
+	var wlist = JSON.parse(PrefServ.getter('extensions.agentSpoof.fullWhiteList'))
 
-	for (var i = 0, len = wlist.length ; i < len ; i++) {
+        for (var i = 0, len = wlist.length ; i < len ; i++) {
 
 		if (url.indexOf(wlist[i].url) > -1){
 			//check the config for the url now confirmed to be in the list
 			checkWhiteListConfig(wlist[i], listStates);
 			return true;
-		}
+		} else if (wlist[i].options && wlist[i].options[0] == 'regexp') {
+                        var regexp = new RegExp(wlist[i].url);
+                        if (regexp.test(url)) {
+                                checkWhiteListConfig(wlist[i], listStates);
+                                return true;
+                        }
+                }
 	}
 
 	return false;
@@ -53,7 +59,6 @@ exports.listCheck = function (url, listStates) {
 
 //check for header related whitelist options
 function checkWhiteListConfig(wlEntry, listStates) {
-
 	if (wlEntry.options) {
 
 		for (var s in listStates){
@@ -68,7 +73,7 @@ function checkWhiteListConfig(wlEntry, listStates) {
 
 // (Re)set whitelist values to false¬
 function resetListStates(states) {
-	
+
 	for (var i in states) {
 		states[i] = false;
 	}


### PR DESCRIPTION
I added the ability to use JS regular expressions in the url field of whitelists. You just have to use "regexp" as the first option to enable RegExp matching. I did it in order to bypass the impossibility to use pdfjs while disabling canvas.

This simple configuration will allow you to disable canvas and still use pdfjs!
`{"url": ".*\\.pdf", "options":["regexp", "canvas"]}`

Since I didn't really know the development philosophy of RAS I'd be glad if you tell me to do it by another way. (Using another field than URL, ...)

Signed-off-by: Ilan ilan.dubois@gmail.com
